### PR TITLE
Add LOEditor to WYSIWYG jQuery list.

### DIFF
--- a/readme-zh-CN.md
+++ b/readme-zh-CN.md
@@ -58,6 +58,7 @@
 - [Dante Editor](https://github.com/michelson/Dante) - 只是另一个 Medium wysiwyg 编辑器的克隆。 ![github star](https://img.shields.io/github/stars/michelson/Dante.svg?style=social&label=Star)
 - [Easyeditor](https://github.com/im4aLL/easyeditor) - 非常轻量级和高度可配置的富文本 HTML 编辑器。 `💤 Inactive` ![github star](https://img.shields.io/github/stars/im4aLL/easyeditor.svg?style=social&label=Star)
 - [jQuery-Notebook](https://github.com/raphaelcruzeiro/jquery-notebook) - 一个现代、简单、优雅的所见即所得的富文本编辑器。 `💤 Inactive` ![github star](https://img.shields.io/github/stars/raphaelcruzeiro/jquery-notebook.svg?style=social&label=Star)
+- [LOEditor](https://github.com/LacasuriOrtodoxe/LOEditor/) - 简洁的现代编辑器，API 简单，无已弃用的 execCommand。
 - [popline](https://github.com/kenshin54/popline) - 一个 HTML5 富文本编辑器的工具栏。 ![github star](https://img.shields.io/github/stars/kenshin54/popline.svg?style=social&label=Star)
 - [simditor](https://github.com/mycolorway/simditor) - 一个简单而快速的所见即所得编辑器。 `💤 Inactive` ![github star](https://img.shields.io/github/stars/mycolorway/simditor.svg?style=social&label=Star)
 - [Summernote](https://github.com/summernote/summernote) - 超级简单的 WYSIWYG 编辑器。 ![github star](https://img.shields.io/github/stars/summernote/summernote.svg?style=social&label=Star)

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ jQuery required editors
 - [Dante Editor](https://github.com/michelson/Dante) - Just another Medium wysiwyg editor clone.
 - [Easyeditor](https://github.com/im4aLL/easyeditor) - Very lightweight and highly configurable rich text html editor. `💤 Inactive`
 - [jQuery-Notebook](https://github.com/raphaelcruzeiro/jquery-notebook) - A modern, simple and elegant WYSIWYG rich text editor. `💤 Inactive`
+- [LOEditor](https://github.com/LacasuriOrtodoxe/LOEditor) - Clean, modern editor with simple API and no deprecated execCommand.
 - [popline](https://github.com/kenshin54/popline) - An HTML5 Rich-Text-Editor Toolbar.
 - [simditor](https://github.com/mycolorway/simditor) - An Easy and Fast WYSIWYG Editor. `💤 Inactive`
 - [Summernote](https://github.com/summernote/summernote) - Super simple WYSIWYG editor.


### PR DESCRIPTION
Hello! I think this editor should be included on the list of jQuery-based editors:

- https://github.com/LacasuriOrtodoxe/LOEditor/
- LOEditor: A lightweight, extensible, and customizable WYSIWYG (What You See Is What You Get) HTML editor with clean output and an easy-to-use JavaScript API. Built with vanilla JavaScript and jQuery, LOEditor avoids the deprecated document.execCommand() and provides a modern, plugin-based architecture for seamless integration into web applications.

